### PR TITLE
Make Wikipedia section clickable and add hover effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,12 +43,14 @@
           </div>
         </div>
       </div>
-      <div class="wiki-container">
-        <div class="wiki-title">
-          Wikipedia information
+      <a id="wiki-link" href="#" style="text-decoration: none; color: inherit;">
+        <div class="wiki-container">
+          <div class="wiki-title">
+            Wikipedia information
+          </div>
+          <div id="wiki-data"></div>
         </div>
-        <div id="wiki-data"></div>
-      </div>
+      </a>
     </div>
   </body>
 

--- a/script.js
+++ b/script.js
@@ -47,6 +47,12 @@ function updateData() {
         document.getElementById("wiki-data").innerHTML = wikiData.extract;
       });
 
+      const wikiLink = document.getElementById("wiki-link");
+      if (wikiLink) {
+        wikiLink.setAttribute("href", currentAlbum.wikipediaUrl);
+        wikiLink.setAttribute("target", "_blank");
+      }
+
       document.getElementById("previous-rating-container").innerHTML =
         generateStars(prevAlbum.averageRating);
       document.getElementById("previous-rating-numerical").innerHTML =

--- a/style.css
+++ b/style.css
@@ -120,6 +120,7 @@
   margin: 4px;
   border: 1px solid #a1a1a1;
   border-radius: 0.5rem;
+  cursor: pointer;
 }
 
 .code-title {
@@ -147,6 +148,14 @@
   text-align: center;
   margin-bottom: 1rem;
   border-bottom: 1px solid #a1a1a1;
+}
+
+#wiki-link:hover .wiki-container {
+  border-color: #555;
+}
+
+#wiki-link {
+  cursor: pointer;
 }
 
 #wiki-data {


### PR DESCRIPTION
This commit introduces the following changes:

1.  The Wikipedia information section (`.wiki-container`) is now a clickable link that directs you to the relevant Wikipedia page for the current album. The link opens in a new tab.
2.  A hover effect has been added to the Wikipedia section:
    *   The border of the `.wiki-container` darkens slightly on hover.
    *   The mouse cursor changes to a pointer.
3.  The `.code-item` elements (Spotify, YouTube Music, etc.) now also have a pointer cursor on hover to better indicate their clickability, complementing the existing JavaScript click handlers.

These changes enhance your experience by making it easier to access external resources related to the displayed album.